### PR TITLE
We use a SHA256 cert from Comodo

### DIFF
--- a/api/index.md
+++ b/api/index.md
@@ -31,7 +31,7 @@ There is however a limit in terms of backward compability and at any time only t
 
 ### Access and Security
 
-Any and all communication is encrypted using a 4096 Bit SHA1 RSA certificate issued by Geotrust using the protocols TLS 1.0, 1.1 &amp; 1.2.
+Any and all communication is encrypted using a 4096 Bit SHA256 RSA certificate issued by Comodo using the protocols TLS 1.0, 1.1 &amp; 1.2.
 
 To interact with our API you will need to [create a user](https://manage.quickpay.net/#/login). With this user you can create multiple merchant accounts or be connected to existing merchant accounts.
 


### PR DESCRIPTION
    curl -v -H 'Accept-Version: v10' https://api.quickpay.net/ping
    *   Trying 52.16.171.110...
    * SSL connection using TLS1.2 / ECDHE_RSA_AES_128_GCM_SHA256
    *    server certificate verification OK
    *    server certificate status verification SKIPPED
    *    common name: *.quickpay.net (matched)
    *    server certificate expiration date OK
    *    server certificate activation date OK
    *    certificate public key: RSA
    *    certificate version: #3
    *    subject: C=DK,postalCode=8000,ST=Denmark,L=Aarhus,street=Oestergade 25\, 1. tv.,O=Quickpay APS,OU=PremiumSSL Wildcard,CN=*.quickpay.net
    *    start date: Wed, 04 Mar 2015 00:00:00 GMT
    *    expire date: Sun, 04 Mar 2018 23:59:59 GMT
    *    issuer: C=GB,ST=Greater Manchester,L=Salford,O=COMODO CA Limited,CN=COMODO RSA Organization Validation Secure Server CA
    *    compression: NULL
    ...